### PR TITLE
Refactor the way we find and load mods to search for dependencies

### DIFF
--- a/source/sledgelib/modloader.cs
+++ b/source/sledgelib/modloader.cs
@@ -345,9 +345,21 @@ internal class CModLoader
     {
         // ModsPath can't be 1, because Init already checks for it
         #pragma warning disable CS8604
+        string[] ModFiles = Directory.GetFiles(ModsPath, "*.dll", SearchOption.TopDirectoryOnly);
         string[] ModDirectories = Directory.GetDirectories(ModsPath, "*", SearchOption.TopDirectoryOnly);
         #pragma warning restore CS8604
 
+        // Register all single .dll mods inside the mods/ directory
+        foreach (string sModFilePath in ModFiles)
+        {
+            string sModName = Path.GetFileNameWithoutExtension(sModFilePath);
+            if (sModName == "sledgelib")
+                continue;
+
+            RegisterMod(sModFilePath, sModName);
+        }
+
+        // Register all mods that are in folders in the mods/ directory 
         foreach (string sModFileFolder in ModDirectories)
         {
             // This will get the name of the folder directory, the mod .dll must match the folder name 

--- a/source/sledgelib/modloader.cs
+++ b/source/sledgelib/modloader.cs
@@ -345,12 +345,12 @@ internal class CModLoader
     {
         // ModsPath can't be 1, because Init already checks for it
         #pragma warning disable CS8604
-        string[] ModDirectories = Directory.GetDirectories(ModsPath, "sledge*", SearchOption.TopDirectoryOnly);
+        string[] ModDirectories = Directory.GetDirectories(ModsPath, "*", SearchOption.TopDirectoryOnly);
         #pragma warning restore CS8604
 
         foreach (string sModFileFolder in ModDirectories)
         {
-            // This will get the name of the folder directory, the mod .dll must match the folder name (e.g sledge_MOD) 
+            // This will get the name of the folder directory, the mod .dll must match the folder name 
             string sModName = Path.GetFileName(sModFileFolder); 
             string sModDepsPath = sModFileFolder + "\\dependencies";
 


### PR DESCRIPTION
Closes #1.

This commit requires that all mods live under a folder inside the `mods/` directory with a prefix of `sledge_`. The mod directory name MUST match the mods `.dll` name. In each mod directory, you can create a `dependencies/` folder which contains `.dll` that should be loaded for your mod.

This changes the way we structure mods in the `mods/` folder. I am open to feedback if we don't like this way of loading mods. Perhaps we can have a hybrid model, if it's a simple mod and only 1 `.dll` file, we don't require a folder to be created? 