### PR TITLE
"Mods" page in loader updated

### DIFF
--- a/source/loader/ui/menu.cpp
+++ b/source/loader/ui/menu.cpp
@@ -10,6 +10,9 @@
 
 #include <imgui_internal.h>
 
+#include <filesystem>
+#include <sstream>
+
 float fTopBarHeight;
 float fTopBarPadding;
 float fIconPadding;
@@ -94,6 +97,20 @@ void Menu::Draw() {
 		case 0:
 			ImGui::SetCursorPos(ImVec2(fIconPadding, (fIconPadding / 4) + fTopBarHeight));
 			ImGui::Image((void*)(intptr_t)iIconTexture, vIconSize);
+			break;
+		case 1:
+			ImGui::Text("Downloaded mods:");
+
+			for (auto const& p : std::filesystem::directory_iterator("mods")) {
+				if (p.is_directory()) {
+					std::stringstream ss;
+
+					ss << "\t" << p.path().filename();
+
+					ImGui::Text(ss.str().c_str());
+				}
+			}
+
 			break;
 		}
 


### PR DESCRIPTION
I added a check for all mods to mods/ so that the Mods page is not empty. Now all downloaded modifications are shown there.
![image](https://user-images.githubusercontent.com/43351072/147875583-b6112da0-12f0-4cbe-b8d1-6c9f09135c04.png)
